### PR TITLE
Loosen version restrictions.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.200"
+    "version": "3.1.200",
+    "rollForward": "latestFeature"
   },
   "version": "8.0.0-alpha1",
   "doc_current": "master",


### PR DESCRIPTION
Using just '3.1.200' requires someone to have that _exact_ version. 'latestFeature' I believe allows the last section to float.