### PR TITLE
Add nuget-config-dir parameter support.

### DIFF
--- a/src/assembly-differ/Providers/NuGet/NuGet.cs
+++ b/src/assembly-differ/Providers/NuGet/NuGet.cs
@@ -19,15 +19,25 @@ namespace Differ.Providers.NuGet
 		NuGetPackage InstallPackage(string packageName, string version, string targetDirectory);
 	}
 
+	public class NuGetInstallerOptions
+	{
+		public string NuGetConfigSearchDirectory { get; set; }
+	}
+
 	public class NuGet : INuGet
 	{
+		protected NuGetInstallerOptions Options { get; }
+
+		public NuGet(NuGetInstallerOptions options)
+			=> Options = options;
+
 		public virtual NuGetPackage InstallPackage(string packageName, string version, string targetDirectory)
 		{
 			if (!Directory.Exists(targetDirectory)) Directory.CreateDirectory(targetDirectory);
 
 			var packageVersion = NuGetVersion.Parse(version);
 			var nuGetFramework = NuGetFramework.AnyFramework;
-			var settings = Settings.LoadDefaultSettings(root: null);
+			var settings = Settings.LoadDefaultSettings(root: Options?.NuGetConfigSearchDirectory);
 			var sourceRepositoryProvider = new SourceRepositoryProvider(
 				new PackageSourceProvider(settings), Repository.Provider.GetCoreV3());
 

--- a/src/assembly-differ/Providers/PreviousNuget/PreviousNugetLocator.cs
+++ b/src/assembly-differ/Providers/PreviousNuget/PreviousNugetLocator.cs
@@ -13,6 +13,9 @@ namespace Differ.Providers.PreviousNuGet
 {
 	public class PreviousNugetLocator : Differ.Providers.NuGet.NuGet
 	{
+		public PreviousNugetLocator(NuGetInstallerOptions options) : base(options)
+		{}
+
 		public override NuGetPackage InstallPackage(string packageName, string currentVersion, string targetDirectory)
 		{
 			var nugetVersion = new NuGetVersion(currentVersion);


### PR DESCRIPTION
Fixes #24

This is just an attempt, but I'm not committed to anything. The main challenge is that providers needs to be initialized, so we can't easily inject changes from options. Options I saw in order from least to most aggressive:

1. Use similar environment variable technique as you did with git.
    - This might be the simplest and cleanest, its just missing clear documents and personally it makes me ask "shouldn't we be able to configure providers during arg parsing"?
1. Pass an options object that is subject to change.
    -  What I went with, but a little bleh for me imo. I'm not a huge fan of things patterns taking advantage of mutability.
1. Add a new parameter to `INuGet.InstallPackage` that takes the nuget config directory, then somehow change the `AssemblyProviderFactory` post argument parsing. 
    - This requires us to find the NuGetAssemblyProviderFactory and make changes to it post initialization. Get's a little gross and similar in problems as the preivous solution.
1. Rework code to support getting the information about each provider so that it can be shown in help, but the initialization of the providers happens _**after**_ argument parsing.